### PR TITLE
Migrated to use the https version of xkcd

### DIFF
--- a/lib/xkcd.coffee
+++ b/lib/xkcd.coffee
@@ -9,7 +9,7 @@
 # Author:
 #  nounoursheureux
 
-url = 'http://xkcd.com'
+url = 'https://xkcd.com'
 
 sendComic = (res, body) ->
   data = JSON.parse body


### PR DESCRIPTION
http://xkcd.com/*/info.0.json redirects to https://xkcd.com/*/info.0.json. We can cut the extra request and migrate to use the https version.